### PR TITLE
Extract CLI and introduce StructOpt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "approx"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -23,6 +32,17 @@ name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "autocfg"
@@ -76,6 +96,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +127,7 @@ dependencies = [
  "ignore",
  "mimalloc",
  "nom",
+ "structopt",
 ]
 
 [[package]]
@@ -131,6 +167,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ignore"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +220,12 @@ dependencies = [
  "ryu",
  "static_assertions",
 ]
+
+[[package]]
+name = "libc"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -222,6 +282,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "radium"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,10 +369,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2af957a63d6bd42255c359c93d9bfdb97076bd3b820897ce55ffbfbf107f44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e"
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
 
 [[package]]
 name = "thread_local"
@@ -280,6 +432,30 @@ checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 ignore = "0.4"
 nom = "6"
 mimalloc = { version = "*", default-features = false }
+structopt = "0.3"
 
 [dev-dependencies]
 approx = "0.4"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,42 @@
+use crate::*;
+use ignore::{DirEntry, WalkBuilder, WalkState};
+use structopt::StructOpt;
+
+pub fn run() {
+    let flags = flags::Flags::from_args();
+    let mut builder = WalkBuilder::new("./");
+    let mut files_filter = FilesFilter::default();
+
+    flags
+        .ignore
+        .into_iter()
+        .for_each(|i| files_filter.ignored_paths.push(i));
+
+    flags
+        .only
+        .into_iter()
+        .for_each(|i| files_filter.only_paths.push(i));
+
+    builder.filter_entry(move |e| files_filter.matches(e.path()));
+
+    builder.build_parallel().run(|| {
+        Box::new(|result| {
+            render_result(result);
+
+            WalkState::Continue
+        })
+    });
+}
+
+fn render_result(result: Result<DirEntry, ignore::Error>) {
+    if let Some(parsed_file) = result
+        .ok()
+        .and_then(|entry| ParsedFile::new(entry.path().to_path_buf()).ok())
+    {
+        println!(
+            "{:>8} {}",
+            format!("{:.2}", parsed_file.complexity_score),
+            parsed_file.path.display()
+        );
+    }
+}

--- a/src/files_filter.rs
+++ b/src/files_filter.rs
@@ -1,9 +1,9 @@
-use ignore::DirEntry;
 use std::ffi::OsStr;
 
 pub struct FilesFilter<'a> {
     ignored_extensions: Vec<&'a OsStr>,
-    ignored_paths: Vec<&'a str>,
+    pub ignored_paths: Vec<String>,
+    pub only_paths: Vec<String>,
 }
 
 impl<'a> Default for FilesFilter<'a> {
@@ -20,14 +20,15 @@ impl<'a> Default for FilesFilter<'a> {
                 OsStr::new("xml"),
                 OsStr::new("svg"),
             ],
-            ignored_paths: vec!["vendor"],
+            ignored_paths: vec!["vendor".to_string()],
+            only_paths: vec![],
         }
     }
 }
 
 impl<'a> FilesFilter<'a> {
-    pub fn matches(&self, entry: &DirEntry) -> bool {
-        self.approved_extension(entry.path()) && self.approved_path(entry.path())
+    pub fn matches(&self, path: &std::path::Path) -> bool {
+        self.approved_extension(path) && self.approved_path(path) && self.only_path(path)
     }
 
     fn approved_extension(&self, path: &std::path::Path) -> bool {
@@ -41,5 +42,37 @@ impl<'a> FilesFilter<'a> {
         self.ignored_paths
             .iter()
             .all(|ignored| !path.to_str().unwrap_or("").contains(ignored))
+    }
+
+    fn only_path(&self, path: &std::path::Path) -> bool {
+        if path.is_dir() {
+            return true;
+        }
+
+        if self.only_paths.len() > 0 {
+            self.only_paths
+                .iter()
+                .any(|p| path.to_str().unwrap_or("").contains(p))
+        } else {
+            true
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn only_path_allows_directories() {
+        // if only_path is a directory and doesn't match the value, it will prevent that directory
+        // from being traversed further
+        let mut files_filter = FilesFilter::default();
+        files_filter.only_paths.push("js".to_string());
+
+        assert!(files_filter.only_path(Path::new("./src/")));
+        assert!(files_filter.only_path(Path::new("./src/nested.js")));
+        assert!(!files_filter.only_path(Path::new("./src/nested.rb")));
     }
 }

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -1,0 +1,20 @@
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "complexity",
+    about = "A command line tool to identify complex code",
+    setting = structopt::clap::AppSettings::ColoredHelp
+)]
+pub struct Flags {
+    /// Ignore files/directories matching the provided value
+    ///
+    /// This supports providing multiple values with a comma-delimited list
+    #[structopt(long, use_delimiter = true)]
+    pub ignore: Vec<String>,
+    /// Only files/directories matching the provided value
+    ///
+    /// This supports providing multiple values with a comma-delimited list
+    #[structopt(long, use_delimiter = true)]
+    pub only: Vec<String>,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
+pub mod cli;
 mod complexity_score;
 mod files_filter;
+pub mod flags;
 mod parsed_file;
 mod parser;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,31 +1,6 @@
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-use complexity::*;
-use ignore::{DirEntry, WalkBuilder, WalkState};
-
 fn main() {
-    let mut builder = WalkBuilder::new("./");
-    builder.filter_entry(|e| FilesFilter::default().matches(e));
-
-    builder.build_parallel().run(|| {
-        Box::new(|result| {
-            render_result(result);
-
-            WalkState::Continue
-        })
-    });
-}
-
-fn render_result(result: Result<DirEntry, ignore::Error>) {
-    if let Some(parsed_file) = result
-        .ok()
-        .and_then(|entry| ParsedFile::new(entry.path().to_path_buf()).ok())
-    {
-        println!(
-            "{:>8} {}",
-            format!("{:.2}", parsed_file.complexity_score),
-            parsed_file.path.display()
-        );
-    }
+    complexity::cli::run()
 }


### PR DESCRIPTION
What?
=====

This introduces structopt to make CLI interactions more pleasant.
Additionally, this adds support for filtering down results to ONLY those
that match a substring. These can be combined, e.g.

$ complexity --only app,lib --ignore js,scss,html