### PR TITLE
Support YAML configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,10 +124,14 @@ name = "complexity"
 version = "0.1.0"
 dependencies = [
  "approx",
+ "dirs-next",
  "ignore",
  "mimalloc",
  "nom",
+ "serde",
+ "serde_yaml",
  "structopt",
+ "totems",
 ]
 
 [[package]]
@@ -142,6 +146,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99de365f605554ae33f115102a02057d4fc18b01f3284d6870be0938743cfe7d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "dtoa"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +183,17 @@ name = "funty"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ba62103ce691c2fd80fbae2213dfdda9ce60804973ac6b6e97de818ea7f52c8"
+
+[[package]]
+name = "getrandom"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "globset"
@@ -235,6 +277,12 @@ checksum = "82151ff13433c4d403cb15d0e6fbda14b24d65bd1a5b33f7d52ec983cc00752d"
 dependencies = [
  "cmake",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 
 [[package]]
 name = "log"
@@ -330,6 +378,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
+name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+
+[[package]]
+name = "redox_users"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+]
+
+[[package]]
 name = "regex"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,6 +424,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7baae0a99f1a324984bcdc5f0718384c1f69775f1c7eec8b859b71b443e3fd7"
+dependencies = [
+ "dtoa",
+ "linked-hash-map",
+ "serde",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -434,6 +530,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "totems"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced1de49b4b4739691bea1784503e2bda0466b98ce2988307594058a8d57e16a"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +577,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,3 +618,12 @@ name = "wyz"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d"
+dependencies = [
+ "linked-hash-map",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,13 @@ ignore = "0.4"
 nom = "6"
 mimalloc = { version = "*", default-features = false }
 structopt = "0.3"
+serde = { version = "1.0", features = ["derive"] }
+serde_yaml = "0.8"
+dirs-next = "2.0"
 
 [dev-dependencies]
 approx = "0.4"
+totems = "0.2"
 
 [profile.release]
 lto = "fat"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,8 +4,23 @@ use structopt::StructOpt;
 
 pub fn run() {
     let flags = flags::Flags::from_args();
+
+    match flags.cmd {
+        Some(flags::Command::InstallConfiguration) => match configuration::install() {
+            Some(path) => println!("Installed configuration successfully at {}", path.display()),
+            None => println!("Error installing configuration"),
+        },
+        None => calculate_complexity(flags),
+    }
+}
+
+fn calculate_complexity(flags: flags::Flags) {
     let mut builder = WalkBuilder::new("./");
-    let mut files_filter = FilesFilter::default();
+    let parsed_value =
+        configuration::load_and_parse_config().and_then(|v| IgnoredFilter::from_file(&v).ok());
+    let mut files_filter: FilesFilter = parsed_value
+        .map(|v| v.into())
+        .unwrap_or(FilesFilter::default());
 
     flags
         .ignore

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,0 +1,33 @@
+use dirs_next;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+pub fn install() -> Option<PathBuf> {
+    let path = config_path().map(PathBuf::from)?;
+
+    path.parent()
+        .and_then(|path| fs::create_dir_all(path).ok())?;
+    fs::write(&path, include_str!("templates/config.yml")).ok()?;
+
+    Some(path)
+}
+
+pub fn load_and_parse_config() -> Option<String> {
+    config_path().and_then(|path| read_file(&path).ok())
+}
+
+fn config_path() -> Option<String> {
+    file_path_in_home_dir(".config/complexity/complexity.yml")
+}
+
+fn file_path_in_home_dir(file_name: &str) -> Option<String> {
+    dirs_next::home_dir()
+        .and_then(|ref p| Path::new(p).join(file_name).to_str().map(|v| v.to_owned()))
+}
+
+fn read_file(filename: &str) -> Result<String, io::Error> {
+    let contents = fs::read_to_string(filename)?;
+
+    Ok(contents)
+}

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -1,6 +1,12 @@
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
+pub enum Command {
+    /// Write the default YAML configuration to the configuration directory
+    InstallConfiguration,
+}
+
+#[derive(Debug, StructOpt)]
 #[structopt(
     name = "complexity",
     about = "A command line tool to identify complex code",
@@ -17,4 +23,7 @@ pub struct Flags {
     /// This supports providing multiple values with a comma-delimited list
     #[structopt(long, use_delimiter = true)]
     pub only: Vec<String>,
+
+    #[structopt(subcommand)]
+    pub cmd: Option<Command>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cli;
 mod complexity_score;
+pub mod configuration;
 mod files_filter;
 pub mod flags;
 mod parsed_file;

--- a/src/templates/config.yml
+++ b/src/templates/config.yml
@@ -1,0 +1,14 @@
+ignored_extensions:
+  - json
+  - lock
+  - toml
+  - yml
+  - yaml
+  - md
+  - markdown
+  - xml
+  - svg
+  - html
+ignored_paths:
+  - vendor
+  - public


### PR DESCRIPTION
What?
=====

This introduces YAML configuration support for default
filtering/ignoring of a base set of file extensions (beyond the base set
of ignoring things from .gitignore).