### PR TITLE
Allow for multiple output types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,7 @@ dependencies = [
  "mimalloc",
  "nom",
  "serde",
+ "serde_json",
  "serde_yaml",
  "structopt",
  "totems",
@@ -243,6 +244,12 @@ dependencies = [
  "walkdir",
  "winapi-util",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "lazy_static"
@@ -444,6 +451,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ mimalloc = { version = "*", default-features = false }
 structopt = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
+serde_json = "1.0"
 dirs-next = "2.0"
 
 [dev-dependencies]

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -1,9 +1,30 @@
+use std::str::FromStr;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 pub enum Command {
     /// Write the default YAML configuration to the configuration directory
     InstallConfiguration,
+}
+
+#[derive(Debug)]
+pub enum Format {
+    Standard,
+    Csv,
+    Json,
+}
+
+impl FromStr for Format {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_ref() {
+            "standard" => Ok(Format::Standard),
+            "csv" => Ok(Format::Csv),
+            "json" => Ok(Format::Json),
+            v => Err(format!("Unknown format: {}", v)),
+        }
+    }
 }
 
 #[derive(Debug, StructOpt)]
@@ -26,4 +47,8 @@ pub struct Flags {
 
     #[structopt(subcommand)]
     pub cmd: Option<Command>,
+
+    /// Format output
+    #[structopt(long, possible_values = &["standard", "csv", "json"], default_value = "standard", case_insensitive = true)]
+    pub format: Format,
 }


### PR DESCRIPTION
What?
=====

This introduces two additional output types: CSV and JSON. This can be
configured via a `--format` flag.