### PR TITLE
Reduce memory usage

### DIFF
--- a/src/parsed_file.rs
+++ b/src/parsed_file.rs
@@ -7,7 +7,6 @@ use std::path::PathBuf;
 #[derive(Debug)]
 pub struct ParsedFile {
     pub path: PathBuf,
-    stats: Vec<usize>,
     pub complexity_score: f32,
 }
 
@@ -36,7 +35,6 @@ impl ParsedFile {
 
         Ok(ParsedFile {
             path,
-            stats,
             complexity_score,
         })
     }


### PR DESCRIPTION
What?
=====

This removes the stored whitespace counts on each parsed file, reducing
overall memory usage. On small projects, this accounts for ~20%
reduction in memory. On very large projects, it can be upwards of a
~70% reduction in memory usage.