### PR TITLE
Set Mimalloc as Optional for build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "complexity"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Joshua Clayton <joshua.clayton@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 serde_json = "1.0"
 dirs-next = "2.0"
-mimalloc = { version = "*", default-features = false }
+mimalloc = { version = "*", default-features = false, optional = true }
 
 [dev-dependencies]
 approx = "0.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#[cfg(all(unix, not(target_env = "musl")))]
+#[cfg(all(feature = "mimalloc", unix, not(target_env = "musl")))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 


### PR DESCRIPTION
Mimalloc has some trouble with the new M1 macbook architecture, setting it to optional should allow the tool to be run on M1. 

See issue: https://github.com/thoughtbot/complexity/issues/13

