### PR TITLE
Improve performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,7 @@ name = "complexity"
 version = "0.4.2"
 dependencies = [
  "approx",
+ "crossbeam-channel",
  "dirs-next",
  "ignore",
  "mimalloc",
@@ -116,6 +117,16 @@ dependencies = [
  "serde_yaml",
  "structopt",
  "totems",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,7 @@ dependencies = [
  "dirs-next",
  "ignore",
  "mimalloc",
+ "num_cpus",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -297,6 +298,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,12 +30,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,18 +51,6 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "bitvec"
-version = "0.19.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ba35e9565969edb811639dbebfe34edc0368e472c5018474c8eb2543397f81"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
 
 [[package]]
 name = "bstr"
@@ -129,7 +111,6 @@ dependencies = [
  "dirs-next",
  "ignore",
  "mimalloc",
- "nom",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -180,12 +161,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "funty"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ba62103ce691c2fd80fbae2213dfdda9ce60804973ac6b6e97de818ea7f52c8"
 
 [[package]]
 name = "getrandom"
@@ -260,19 +235,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec",
- "bitflags",
- "cfg-if 1.0.0",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,18 +277,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5d2c9cb18f9cdc6d88f4aca6d3d8ea89c4c8202d6facfc7e56efdee97b80fa"
 dependencies = [
  "libmimalloc-sys",
-]
-
-[[package]]
-name = "nom"
-version = "6.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88034cfd6b4a0d54dd14f4a507eceee36c0b70e5a02236c4e4df571102be17f0"
-dependencies = [
- "bitvec",
- "lexical-core",
- "memchr",
- "version_check",
 ]
 
 [[package]]
@@ -379,12 +329,6 @@ checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "redox_syscall"
@@ -479,12 +423,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,12 +462,6 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e"
 
 [[package]]
 name = "textwrap"
@@ -632,12 +564,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ license = "MIT"
 
 [dependencies]
 ignore = "0.4"
-nom = "6"
 structopt = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ serde_yaml = "0.8"
 serde_json = "1.0"
 dirs-next = "2.0"
 mimalloc = { version = "*", default-features = false, optional = true }
+crossbeam-channel = "0.5"
 
 [dev-dependencies]
 approx = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = "1.0"
 dirs-next = "2.0"
 mimalloc = { version = "*", default-features = false, optional = true }
 crossbeam-channel = "0.5"
+num_cpus = "1.0"
 
 [dev-dependencies]
 approx = "0.4"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -76,12 +76,16 @@ fn build_scorer(algorithm: &flags::ScoringAlgorithm) -> Box<dyn scoring::ScoreVi
 }
 
 fn render_standard(results: &[ParsedFile]) {
+    use std::io::Write;
+    let mut lock = std::io::stdout().lock();
     for parsed_file in results {
-        println!(
+        writeln!(
+            lock,
             "{:>8} {}",
             format!("{:.2}", parsed_file.complexity_score),
             parsed_file.path.display()
-        );
+        )
+        .unwrap();
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,6 +36,7 @@ fn calculate_complexity(flags: flags::Flags) {
         .for_each(|i| files_filter.only_paths.push(i));
 
     builder.filter_entry(move |e| files_filter.matches(e.path()));
+    builder.threads(num_cpus::get());
 
     let mut results = vec![];
     let scorer = &flags.scorer;

--- a/src/parsed_file.rs
+++ b/src/parsed_file.rs
@@ -12,8 +12,6 @@ pub struct ParsedFile {
 
 pub enum ParsedFileError {
     IoError(std::io::Error),
-    IncompleteParse,
-    FailedParse,
 }
 
 impl From<std::io::Error> for ParsedFileError {
@@ -28,11 +26,7 @@ impl ParsedFile {
         path: PathBuf,
     ) -> Result<Self, ParsedFileError> {
         let contents = get_file_contents(&path)?;
-        let stats = match parser::parse_file(&contents) {
-            Ok(("", stats)) => Ok(stats),
-            Ok(_) => Err(ParsedFileError::IncompleteParse),
-            Err(_) => Err(ParsedFileError::FailedParse),
-        }?;
+        let stats = parser::parse_file(&contents);
         let complexity_score = scoring::score(scorer, &stats);
 
         Ok(ParsedFile {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,33 +1,31 @@
-use nom::{
-    bytes::complete::{tag, take_till},
-    character::complete::space0,
-    combinator::map,
-    multi::{many0, many1, separated_list1},
-    sequence::pair,
-    sequence::terminated,
-    IResult,
-};
+pub fn parse_file(input: &str) -> Vec<usize> {
+    if input.len() == 0 {
+        vec![]
+    } else {
+        let mut result = vec![];
+        let mut whitespace = 0;
+        let mut space = true;
 
-pub fn parse_file(input: &str) -> IResult<&str, Vec<usize>> {
-    let (input, _) = many0(tag("\n"))(input)?;
-    map(
-        terminated(
-            separated_list1(many1(tag("\n")), parse_line),
-            many0(tag("\n")),
-        ),
-        |vs| {
-            vs.into_iter()
-                .filter_map(|(ws, text_present)| if text_present { Some(ws) } else { None })
-                .collect::<Vec<_>>()
-        },
-    )(input)
-}
+        for c in input.chars() {
+            if (c == ' ' || c == '\t') && space {
+                whitespace += 1;
+            } else if c == '\n' {
+                if !space {
+                    result.push(whitespace);
+                }
+                whitespace = 0;
+                space = true;
+            } else {
+                space = false;
+            }
+        }
 
-fn parse_line(input: &str) -> IResult<&str, (usize, bool)> {
-    pair(
-        map(space0, |ws: &str| ws.len()),
-        map(take_till(|c| c == '\n'), |v: &str| v.len() > 0),
-    )(input)
+        if !space {
+            result.push(whitespace);
+        }
+
+        result
+    }
 }
 
 #[cfg(test)]
@@ -36,17 +34,15 @@ mod tests {
 
     #[test]
     fn counts_whitespace_correctly() {
-        assert_eq!(parse_line("    def full_name").unwrap().1, (4, true));
-        assert_eq!(parse_line("class Person; end").unwrap().1, (0, true));
-        assert_eq!(parse_line("").unwrap().1, (0, false));
+        assert_eq!(parse_file("    def full_name"), vec![4]);
+        assert_eq!(parse_file("class Person; end"), vec![0]);
+        assert!(parse_file("").is_empty());
     }
 
     #[test]
     fn parses_a_file() {
         assert_eq!(
-            parse_file("\n\nclass Person;end\n\nclass Dog;end\n\n")
-                .unwrap()
-                .1,
+            parse_file("\n\nclass Person;end\n\nclass Dog;end\n\n"),
             vec![0, 0]
         )
     }


### PR DESCRIPTION
What?
=====

This introduces a series of small performance improvements to better model
handling of parallel walking, a custom state management parser to calculate
leading whitespace, locking stdout once when printing output, and configuring
the parallel file walker to leverage an appropriate number of cores.