### PR TITLE
Improve documentation for --only flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,17 @@ Within the [Discourse codebase], for example, here's what the output might look 
 Additionally, you can limit results by substring with the `--only` flag, or
 modify paths to ignore with `--ignore`.
 
+```sh
+// This filters the .rs files inside all directories and outputs scores in a json format
+complexity --format json --only .rs
+
+// This filters the .rs and .md files inside all directories
+complexity --only .rs,.md
+
+// This filters all the files inside src/scoring directory
+complexity --only src/scoring
+```
+
 You can view the full suite of options by running `complexity help`.
 
 ## License

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -57,6 +57,8 @@ pub struct Flags {
     /// Only files/directories matching the provided value
     ///
     /// This supports providing multiple values with a comma-delimited list
+    ///
+    /// Example: --only .rs,.md
     #[clap(long, value_delimiter = ',')]
     pub only: Vec<String>,
 


### PR DESCRIPTION
Provide examples about how --only flag works in README.md and flag explanation.

There was no information about what kind of format to pass to the --only flag and this caused some issues with running complexity as expected. The examples provided via this change show the correct format.